### PR TITLE
Update to 25.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,1 @@
 aggregate_branch: 3.12
-
-channels:
-  - https://staging.continuum.io/prefect/fs/zeromq-feedstock/pr5/4df21d3

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+aggregate_branch: 3.12
+
+channels:
+  - https://staging.continuum.io/prefect/fs/zeromq-feedstock/pr5/4df21d3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.1.0" %}
+{% set version = "25.1.2" %}
 
 package:
   name: pyzmq
@@ -7,15 +7,11 @@ package:
 source:
   # We use the pypi URL as it includes the prepared Cython files.
   url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
-  sha256: 80c41023465d36280e801564a69cbfce8ae85ff79b080e1913f6e90481fb8957
+  sha256: 93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226
 
 build:
   number: 0
   skip: True  # [py<36]
-  ignore_run_exports:
-    - zeromq  # [win]
-  missing_dso_whitelist:
-    - $RPATH/libzmq.cp*-win_amd64.pyd  # [win]
 
 requirements:
   build:
@@ -30,14 +26,11 @@ requirements:
     - setuptools_scm
     - toml
     - wheel
-    - cython 0.29  # [py<=311]
-    - cython 3.0.0 # [py==312]
-    - libsodium 1.0.18
-    - zeromq 4.3.4
+    - cython >=0.29.35
+    - zeromq 4.3.5
   run:
     - python
-    - libsodium >=1.0.18,<1.0.19.0a0
-    - zeromq >=4.3.4,<4.4.0a0
+    - zeromq >=4.3.5,<4.4.0a0
 
 test:
   imports:
@@ -48,10 +41,6 @@ test:
   requires:
     - pip
     - pytest
-  # We run the zmq tests on all platforms except Windows.
-  # The only reason not to run the tests on Windows is that
-  # they terminate with an interactive prompt. See also
-  # https://github.com/conda-forge/staged-recipes/pull/292#issuecomment-208080893.
   commands:
     - pip check
     - py.test --pyargs zmq.tests.test_socket


### PR DESCRIPTION
Changes:
- Update to 25.1.2
- libsodium is used by zeromq, not directly by pyzmq
- built against update zeromq (which has a strict pin on windows)

https://github.com/zeromq/pyzmq/tree/v25.1.2