### PR TITLE
Backdate to 24.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,8 +50,8 @@ about:
   summary: Python bindings for zeromq
   license: BSD-3-Clause AND LGPL-3.0-or-later
   license_file:
-     - LICENSE.BSD
-     - LICENSE.LESSER
+     - COPYING.BSD
+     - COPYING.LESSER
   license_family: BSD
   description: |
     PyZMQ contains Python bindings for 0MQ. 0MQ is a lightweight and fast

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "25.1.2" %}
+{% set version = "24.0.1" %}
 
 package:
   name: pyzmq
@@ -7,7 +7,7 @@ package:
 source:
   # We use the pypi URL as it includes the prepared Cython files.
   url: https://pypi.io/packages/source/p/pyzmq/pyzmq-{{ version }}.tar.gz
-  sha256: 93f1aa311e8bb912e34f004cf186407a4e90eec4f0ecc0efd26056bf7eda0226
+  sha256: 216f5d7dbb67166759e59b0479bca82b8acf9bed6015b526b8eb10143fb08e77
 
 build:
   number: 0


### PR DESCRIPTION
pyzmq 24.0.1

**Destination channel:** defaults

### Links

- [PKG-4197](https://anaconda.atlassian.net/browse/PKG-4197) 
- [Upstream repository](https://github.com/zeromq/pyzmq)
- [Upstream changelog/diff](https://pyzmq.readthedocs.io/en/latest/changelog.html)

### Explanation of changes:

Need to fill in a version gap in our defaults channel in order to cover certain install use cases for JupyterLab 3.x

[PKG-4197]: https://anaconda.atlassian.net/browse/PKG-4197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ