### PR TITLE
pyzmq 27.1.0: Rebuild for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,9 +1,5 @@
 {% set version = "27.1.0" %}
 {% set name = "pyzmq" %}
-{% set ignore_tests = "" %}
-{% set ignore_tests = ignore_tests + " --ignore=tests/test_log.py" %}  # [linux64]
-{% set tests_to_skip = "" %}
-{% set tests_to_skip = '-k "not test_process_teardown"' %}  # [osx]
 
 package:
   name: {{ name|lower }}
@@ -39,10 +35,15 @@ requirements:
     - cffi  # [python_impl == 'pypy']
     - zeromq  # constraint through run_exports
 
+{% set ignore_tests = "" %}
+{% set tests_to_skip = "" %}
 # CI issue: zmq.error.ZMQError: Socket operation on non-socket
 # Works fine locally on the Docker instance.
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_log.py" %}  # [linux64]
 # E AssertionError: Python process died with code 1
 # E where 1 = <ProcessForTeardownTest name='ProcessForTeardownTest-1' pid=74778 parent=74770 stopped exitcode=1>.exitcode
+{% set tests_to_skip = '-k "not test_process_teardown"' %}  # [unix]
+
 test:
   source_files:
     - pyproject.toml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,9 @@
 {% set version = "27.1.0" %}
 {% set name = "pyzmq" %}
+{% set ignore_tests = "" %}
+{% set ignore_tests = ignore_tests + " --ignore=tests/test_log.py" %}  # [linux64]
+{% set tests_to_skip = "" %}
+{% set tests_to_skip = '-k "not test_process_teardown"' %}  # [osx]
 
 package:
   name: {{ name|lower }}
@@ -11,7 +15,7 @@ source:
   sha256: ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 requirements:
@@ -33,17 +37,12 @@ requirements:
   run:
     - python
     - cffi  # [python_impl == 'pypy']
-    - zeromq # constraint through run_exports
+    - zeromq  # constraint through run_exports
 
-{% set ignore_tests = "" %}
-{% set tests_to_skip = "" %}
 # CI issue: zmq.error.ZMQError: Socket operation on non-socket
 # Works fine locally on the Docker instance.
-{% set ignore_tests = ignore_tests + " --ignore=tests/test_log.py" %}  # [linux64]
 # E AssertionError: Python process died with code 1
 # E where 1 = <ProcessForTeardownTest name='ProcessForTeardownTest-1' pid=74778 parent=74770 stopped exitcode=1>.exitcode
-{% set tests_to_skip = '-k "not test_process_teardown"' %}  # [osx]
-
 test:
   source_files:
     - pyproject.toml


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-10554](https://anaconda.atlassian.net/browse/PKG-10554) 
- [Upstream repository](https://github.com/zeromq/pyzmq/tree/v27.1.0)

### Explanation of changes:

- Bump the build nu,ber to 1.
- Skip test_process_teardown on linux as weel. async tests fail with a new py314.

### Notes:

-

[PKG-10554]: https://anaconda.atlassian.net/browse/PKG-10554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ